### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
-[*.cs]
+[*.{cs,xaml}]
 indent_style=tab
 tab_width=4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+indent_style=tab
+tab_width=4


### PR DESCRIPTION
For users with the [EditorConfig](https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328) extension for Visual Studio installed,
the inclusion of this file removes the need to modify certain settings
related to indentation in order to be consistent with the style used by
this project.